### PR TITLE
Fix function calls overriding control statements

### DIFF
--- a/syntaxes/gsc.tmLanguage
+++ b/syntaxes/gsc.tmLanguage
@@ -1,305 +1,311 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>fileTypes</key>
-	<array>
+	<dict>
+		<key>fileTypes</key>
+		<array>
+			<string>gsc</string>
+		</array>
+
+		<key>name</key>
 		<string>gsc</string>
-	</array>
-    
-	<key>name</key>
-	<string>gsc</string>
-    
-    <key>scopeName</key>
-	<string>source.gsc</string>
-    
-	<key>foldingStartMarker</key>
-	<string>\{</string>
-	<key>foldingStopMarker</key>
-	<string>\}</string>
-	
-	<key>patterns</key>
-	<array>    
-        <!-- #include PreProcessor Directive -->
-        <dict>
-            <key>begin</key>
-			<string>^\s*(#include\b)\s*([^;]*);?</string>
-			<key>beginCaptures</key>
+
+		<key>scopeName</key>
+		<string>source.gsc</string>
+
+		<key>foldingStartMarker</key>
+		<string>\{</string>
+		<key>foldingStopMarker</key>
+		<string>\}</string>
+
+		<key>patterns</key>
+		<array>
+			<!-- #include PreProcessor Directive -->
 			<dict>
-				<key>1</key>
+				<key>begin</key>
+				<string>^\s*(#include\b)\s*([^;]*);?</string>
+				<key>beginCaptures</key>
 				<dict>
-				    <key>name</key>
-				    <string>keyword.control.import.include</string>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>keyword.control.import.include</string>
+					</dict>
+
+					<key>2</key>
+					<dict>
+						<key>name</key>
+						<string>string.filename.gsc</string>
+					</dict>
 				</dict>
-                
-                <key>2</key>
-				<dict>
-				    <key>name</key>
-				    <string>string.filename.gsc</string>
-				</dict>
+
+				<key>end</key>
+				<string>\s</string>
 			</dict>
-            
-			<key>end</key>
-			<string>\s</string>
-        </dict>
-        
-        <!-- #using_animtree PreProcessor Directive
-              behaves slightly differently than #include because of parentheses -->
-        <dict>
-            <key>match</key>
-            <string>#using_animtree\b</string>
-        
-            <key>name</key>
-            <string>meta.preprocessor.c</string>
-        </dict>
-    
-        <!-- Single Line Comments -->
-        <dict>
-            <key>match</key>
-            <string>//.*</string>
-        
-            <key>name</key>
-            <string>comment.line</string>
-        </dict>
-    
-        <!-- Block Comments -->
-		<dict>
-            <key>begin</key>
-			<string>/\*</string>
-			<key>beginCaptures</key>
+
+			<!--
+				#using_animtree PreProcessor Directive
+				behaves slightly differently than #include because of parentheses
+			-->
 			<dict>
-				<key>0</key>
-				<dict>
-				    <key>name</key>
-				    <string>comment.begin</string>
-				</dict>
+				<key>match</key>
+				<string>#using_animtree\b</string>
+
+				<key>name</key>
+				<string>meta.preprocessor.c</string>
 			</dict>
-			<key>end</key>
-			<string>\*/</string>
-			<key>endCaptures</key>
+
+			<!-- Single Line Comments -->
 			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>comment.end</string>
-				</dict>
+				<key>match</key>
+				<string>//.*</string>
+
+				<key>name</key>
+				<string>comment.line</string>
 			</dict>
-            <key>name</key>
-            <string>comment.block.gsc</string>
-        </dict>
-        
-        <!-- Developer Script Blocks 
+
+			<!-- Block Comments -->
+			<dict>
+				<key>begin</key>
+				<string>/\*</string>
+				<key>beginCaptures</key>
+				<dict>
+					<key>0</key>
+					<dict>
+						<key>name</key>
+						<string>comment.begin</string>
+					</dict>
+				</dict>
+				<key>end</key>
+				<string>\*/</string>
+				<key>endCaptures</key>
+				<dict>
+					<key>0</key>
+					<dict>
+						<key>name</key>
+						<string>comment.end</string>
+					</dict>
+				</dict>
+				<key>name</key>
+				<string>comment.block.gsc</string>
+			</dict>
+
+			<!--
+				Developer Script Blocks 
 				string.regexp
 				punctuation.definition.string
-				string.other.link -->
-        <dict>
-            <key>begin</key>
-			<string>/#</string>
-			<key>beginCaptures</key>
+				string.other.link
+			-->
 			<dict>
-				<key>0</key>
+				<key>begin</key>
+				<string>/#</string>
+				<key>beginCaptures</key>
 				<dict>
-				    <key>name</key>
-				    <string>comment.begin</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>#/</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>comment.end</string>
-				</dict>
-			</dict>
-            <key>name</key>
-            <string>comment.block.developerscript.gsc</string>
-        </dict>
-		
-        <!-- String Literals -->
-        <dict>    
-            <key>begin</key>
-			<string>"</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-				    <key>name</key>
-				    <string>punctuation.definition.string.begin.gsc</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?&lt;!\\)["\n\r]</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.gsc</string>
-				</dict>
-			</dict>
-            <key>name</key>
-            <string>string.quoted.double.gsc</string>
-        </dict>
-        
-         <!-- Numeric Literals -->
-        <dict>    
-            <key>match</key>
-            <string>(?&lt;![a-zA-Z]-)(?&lt;![a-zA-Z])\b\d+\.?f?</string>
-            <key>name</key>
-            <string>constant.numeric.c</string>
-        </dict>
-        
-        <dict>    
-            <key>match</key>
-            <string>(i*)\b(true|false|undefined)\b</string>
-            <key>name</key>
-            <string>constant.language.c</string>
-        </dict>
-        
-        <!-- Control Statements -->
-        <dict>
-            <key>match</key>
-            <string>\b(if|else|switch|case|break(point)?|continue|for|while|return|default|waittillframeend|wait|endon|waittill|notify|thread)\b</string>
-                
-            <key>name</key>
-            <string>keyword.control.c</string>
-        </dict>
-        
-        <!-- Hardcoded Variables -->
-        <dict>
-            <key>match</key>
-            <string>\b(level|game|self)\b</string>
-            
-            <key>name</key>
-            <string>support.variable.gsc</string>
-        </dict>
-		
-		<!-- Functions Declarations -->
-		<dict>
-            <key>match</key>
-            <string>(_?[a-zA-Z\-_]\w*)(?=\s*\(.*\).*)</string>
-            
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.function.c</string>
-				</dict>
-			</dict>
-        </dict>
-		
-		<dict>
-			<key>include</key>
-			<string>#block</string>
-		</dict>
-    </array>
-	
-	<key>repository</key>
-	<dict>
-		<!-- Blocks -->
-		<key>block</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>\{</string>
-					<key>beginCaptures</key>
+					<key>0</key>
 					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.block.begin.gsc</string>
-						</dict>
+						<key>name</key>
+						<string>comment.begin</string>
 					</dict>
-					<key>end</key>
-					<string>\}</string>
-					<key>endCaptures</key>
+				</dict>
+				<key>end</key>
+				<string>#/</string>
+				<key>endCaptures</key>
+				<dict>
+					<key>0</key>
 					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.block.end.gsc</string>
-						</dict>
+						<key>name</key>
+						<string>comment.end</string>
 					</dict>
-					
-					<key>name</key>
-					<string>meta.block.gsc</string>
-					
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#block_innards</string>
-						</dict>
-						
-						<!-- Needed for nested blocks -->
-						<dict>
-							<key>include</key>
-							<string>$base</string>
-						</dict>
-					</array>
 				</dict>
-			</array>
-		</dict>
-		
-		<key>block_innards</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#function_call</string>
-				</dict>
-			
-				<dict>
-					<key>include</key>
-					<string>#function_ptr</string>
-				</dict>
-			
-				<!-- Handle nested blocks -->
-				<dict>
-					<key>include</key>
-					<string>#block</string>
-				</dict>
-			</array>
-		</dict>
-		
-		<!-- Function Calls -->
-		<key>function_call</key>
-		<dict>
-            <key>match</key>
-            <string>(_?[a-zA-Z\-_]\w*)(?=\s*\(.*\).*)</string>
-            
-			<key>captures</key>
+				<key>name</key>
+				<string>comment.block.developerscript.gsc</string>
+			</dict>
+
+			<!-- String Literals -->
 			<dict>
-				<key>1</key>
+				<key>begin</key>
+				<string>"</string>
+				<key>beginCaptures</key>
 				<dict>
-					<key>name</key>
-					<string>support.function.any-method.gsc</string>
+					<key>0</key>
+					<dict>
+						<key>name</key>
+						<string>punctuation.definition.string.begin.gsc</string>
+					</dict>
+				</dict>
+				<key>end</key>
+				<string>(?&lt;!\\)["\n\r]</string>
+				<key>endCaptures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>punctuation.definition.string.end.gsc</string>
+					</dict>
+				</dict>
+				<key>name</key>
+				<string>string.quoted.double.gsc</string>
+			</dict>
+
+			<!-- Numeric Literals -->
+			<dict>
+				<key>match</key>
+				<string>(?&lt;![a-zA-Z]-)(?&lt;![a-zA-Z])\b\d+\.?f?</string>
+				<key>name</key>
+				<string>constant.numeric.c</string>
+			</dict>
+
+			<dict>
+				<key>match</key>
+				<string>(i*)\b(true|false|undefined)\b</string>
+				<key>name</key>
+				<string>constant.language.c</string>
+			</dict>
+
+			<!-- Control Statements -->
+			<dict>
+				<key>match</key>
+				<string>\b(if|else|switch|case|break(point)?|continue|for|while|return|default|waittillframeend|wait|endon|waittill|notify|thread)\b</string>
+
+				<key>name</key>
+				<string>keyword.control.c</string>
+			</dict>
+
+			<!-- Hardcoded Variables -->
+			<dict>
+				<key>match</key>
+				<string>\b(level|game|self)\b</string>
+
+				<key>name</key>
+				<string>support.variable.gsc</string>
+			</dict>
+
+			<!-- Functions Declarations -->
+			<dict>
+				<key>match</key>
+				<string>(_?[a-zA-Z\-_]\w*)(?=\s*\(.*\).*)</string>
+
+				<key>captures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>entity.name.function.c</string>
+					</dict>
 				</dict>
 			</dict>
-        </dict>
-		
-		<!-- Function Pointers -->
-		<!-- Ex:   ::my_func;  -->
-		<key>function_ptr</key>
-		<dict>
-            <key>match</key>
-            <string>::\b(\w+)\b</string>
-            
-			<key>captures</key>
+
 			<dict>
-				<key>1</key>
+				<key>include</key>
+				<string>#block</string>
+			</dict>
+		</array>
+
+		<key>repository</key>
+		<dict>
+			<!-- Blocks -->
+			<key>block</key>
+			<dict>
+				<key>patterns</key>
+				<array>
+					<dict>
+						<key>begin</key>
+						<string>\{</string>
+						<key>beginCaptures</key>
+						<dict>
+							<key>0</key>
+							<dict>
+								<key>name</key>
+								<string>punctuation.section.block.begin.gsc</string>
+							</dict>
+						</dict>
+						<key>end</key>
+						<string>\}</string>
+						<key>endCaptures</key>
+						<dict>
+							<key>0</key>
+							<dict>
+								<key>name</key>
+								<string>punctuation.section.block.end.gsc</string>
+							</dict>
+						</dict>
+
+						<key>name</key>
+						<string>meta.block.gsc</string>
+
+						<key>patterns</key>
+						<array>
+							<dict>
+								<key>include</key>
+								<string>#block_innards</string>
+							</dict>
+
+							<!-- Needed for nested blocks -->
+							<dict>
+								<key>include</key>
+								<string>$base</string>
+							</dict>
+						</array>
+					</dict>
+				</array>
+			</dict>
+
+			<key>block_innards</key>
+			<dict>
+				<key>patterns</key>
+				<array>
+					<dict>
+						<key>include</key>
+						<string>#function_call</string>
+					</dict>
+
+					<dict>
+						<key>include</key>
+						<string>#function_ptr</string>
+					</dict>
+
+					<!-- Handle nested blocks -->
+					<dict>
+						<key>include</key>
+						<string>#block</string>
+					</dict>
+				</array>
+			</dict>
+
+			<!-- Function Calls -->
+			<key>function_call</key>
+			<dict>
+				<key>match</key>
+				<string>(_?[a-zA-Z\-_]\w*)(?=\s*\(.*\).*)</string>
+
+				<key>captures</key>
 				<dict>
-					<key>name</key>
-					<string>support.function.any-method.gsc</string>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>support.function.any-method.gsc</string>
+					</dict>
 				</dict>
 			</dict>
-        </dict>
+
+			<!--
+				Function Pointers
+				Example: ::my_func;
+			-->
+			<key>function_ptr</key>
+			<dict>
+				<key>match</key>
+				<string>::\b(\w+)\b</string>
+
+				<key>captures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>support.function.any-method.gsc</string>
+					</dict>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
-</dict>
 </plist>

--- a/syntaxes/gsc.tmLanguage
+++ b/syntaxes/gsc.tmLanguage
@@ -183,7 +183,7 @@
 			<!-- Functions Declarations -->
 			<dict>
 				<key>match</key>
-				<string>(_?[a-zA-Z\-_]\w*)(?=\s*\(.*\).*)</string>
+				<string>((?!if\b|else\b|switch\b|case\b|break(point)?\b|continue\b|for\b|while\b|return\b|default\b|waittillframeend\b|wait\b|endon\b|waittill\b|notify\b|thread\b)\b[a-zA-Z_]\w*)(?=\s*\(.*\).*)</string>
 
 				<key>captures</key>
 				<dict>
@@ -276,7 +276,7 @@
 			<key>function_call</key>
 			<dict>
 				<key>match</key>
-				<string>(_?[a-zA-Z\-_]\w*)(?=\s*\(.*\).*)</string>
+				<string>((?!if\b|else\b|switch\b|case\b|break(point)?\b|continue\b|for\b|while\b|return\b|default\b|waittillframeend\b|wait\b|endon\b|waittill\b|notify\b|thread\b)\b[a-zA-Z_]\w*)(?=\s*\(.*\).*)</string>
 
 				<key>captures</key>
 				<dict>


### PR DESCRIPTION
Fixes #2 

So I have been using this extension for a while and the miscolored control statements when parentheses are added were bothering me.

First commit fixes indentation for the textmate rules (sorry for putting that in the same PR but I didn't want to work with messy indentation), second one fixes the issue described in #2. I did it the way the [Treyarch GSC Extension for BO3](https://github.com/shiversoftdev/vscode-txscript/blob/84d756574d27c438e79283d3a0687b4bdd92d780/syntaxes/gsc.tmLanguage#L425) does it — by excluding the keywords from the function call & function definition regex matches.